### PR TITLE
feat(AST parser): add Python invoker + bootstrapper

### DIFF
--- a/xunit-autolabeler-v2/ast_parser/python/README.md
+++ b/xunit-autolabeler-v2/ast_parser/python/README.md
@@ -1,0 +1,15 @@
+# AST snippet parser - Python
+
+## What this does
+This tool extracts snippet data from Python snippets [such as these](https://github.com/googlecloudplatform/python-docs-samples), and serializes that data into a language-agnostic JSON format.
+
+That data can then be used by the "meta-parser" in `ast_parser/core` to match test results with their associated snippets/region tags.
+
+## Usage
+Run the following command to generate a `polyglot_snippet_data.json` file for a specific directory:
+
+```
+python python_bootstrap.py YOUR_SAMPLE_DIR
+```
+
+**Do not** move the generated `polyglot_snippet_data.json` file, as this will break its stored filepaths.

--- a/xunit-autolabeler-v2/ast_parser/python/invoker.py
+++ b/xunit-autolabeler-v2/ast_parser/python/invoker.py
@@ -13,7 +13,7 @@
 # limitations under the License.
 
 import os
-from typing import Any, List
+from typing import Any, Dict, List
 
 from ast_parser.lib import file_utils
 
@@ -32,7 +32,7 @@ def _parse_test(test_path: str, source_methods: List[Any]) -> None:
     test_parser.store_tests_on_methods(source_methods, test_method_map)
 
 
-def get_json_for_dir(root_dir: str) -> str:
+def get_json_for_dir(root_dir: str) -> List[Dict]:
     python_files = file_utils.get_python_files(root_dir)
 
     source_methods = []

--- a/xunit-autolabeler-v2/ast_parser/python/invoker.py
+++ b/xunit-autolabeler-v2/ast_parser/python/invoker.py
@@ -1,0 +1,57 @@
+# Copyright 2020 Google LLC.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+
+import json
+import os
+
+from ast_parser.lib import file_utils
+from . import constants, source_parser, test_parser
+from typing import Any, List
+
+
+def _parse_source(source_path: str) -> List[Any]:
+    source_methods = source_parser.get_top_level_methods(source_path)
+    return [method for method in source_methods]
+
+
+def _parse_test(test_path: str, source_methods: List[Any]) -> None:
+    test_methods = test_parser.get_test_methods(test_path)
+    test_method_map = test_parser.get_test_key_to_snippet_map(test_methods)
+
+    test_parser.store_tests_on_methods(source_methods, test_method_map)
+
+
+def get_json_for_dir(root_dir: str) -> str:
+    python_files = file_utils.get_python_files(root_dir)
+
+    source_methods = []
+    source_files = [file for file in python_files
+                    if constants.TEST_FILE_MARKER not in file]
+
+    for file in source_files:
+        source_methods += _parse_source(file)
+
+    test_files = [file for file in python_files
+                  if constants.TEST_FILE_MARKER in file]
+
+    for file in test_files:
+        _parse_test(file, source_methods)
+
+    for method in source_methods:
+        new_source_path = os.path.relpath(
+            method.drift.source_path, root_dir)
+        method.drift._replace(source_path=new_source_path)
+
+    return json.dumps([method.drift._asdict() for method in source_methods])

--- a/xunit-autolabeler-v2/ast_parser/python/invoker.py
+++ b/xunit-autolabeler-v2/ast_parser/python/invoker.py
@@ -12,13 +12,12 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-
-import json
 import os
+from typing import Any, List
 
 from ast_parser.lib import file_utils
+
 from . import constants, source_parser, test_parser
-from typing import Any, List
 
 
 def _parse_source(source_path: str) -> List[Any]:
@@ -54,4 +53,4 @@ def get_json_for_dir(root_dir: str) -> str:
             method.drift.source_path, root_dir)
         method.drift._replace(source_path=new_source_path)
 
-    return json.dumps([method.drift._asdict() for method in source_methods])
+    return [method.drift._asdict() for method in source_methods]

--- a/xunit-autolabeler-v2/ast_parser/python/invoker_test.py
+++ b/xunit-autolabeler-v2/ast_parser/python/invoker_test.py
@@ -1,0 +1,61 @@
+# Copyright 2020 Google LLC.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+
+import json
+import os
+
+
+from . import invoker
+
+
+TEST_DATA_PATH = os.path.join(
+    os.path.dirname(__file__),
+    'test_data/parser/edge_cases'
+)
+
+source_path = os.path.join(TEST_DATA_PATH, 'edge_cases.py')
+test_path = os.path.join(TEST_DATA_PATH, 'edge_cases_test.py')
+
+
+def test_recognizes_source_files():
+    methods = invoker._parse_source(source_path)
+
+    assert len(methods) == 1
+
+
+def test_recognizes_test_files():
+    methods = invoker._parse_source(source_path)
+
+    invoker._parse_test(test_path, methods)
+
+    assert len(methods) == 1
+    assert len(methods[0].drift.test_methods) == 1
+
+
+def test_get_json_for_dir():
+    repo_json = invoker.get_json_for_dir(TEST_DATA_PATH)
+
+    repo_obj = json.loads(repo_json)
+    assert len(repo_obj) == 1
+
+    first_repo_obj = repo_obj[0]
+
+    assert 'name' in first_repo_obj
+    assert 'class_name' in first_repo_obj
+    assert 'parser' in first_repo_obj
+    assert 'start_line' in first_repo_obj
+    assert 'end_line' in first_repo_obj
+    assert 'method_name' in first_repo_obj
+    assert 'test_methods' in first_repo_obj

--- a/xunit-autolabeler-v2/ast_parser/python/invoker_test.py
+++ b/xunit-autolabeler-v2/ast_parser/python/invoker_test.py
@@ -12,10 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-
-import json
 import os
-
 
 from . import invoker
 
@@ -45,9 +42,7 @@ def test_recognizes_test_files():
 
 
 def test_get_json_for_dir():
-    repo_json = invoker.get_json_for_dir(TEST_DATA_PATH)
-
-    repo_obj = json.loads(repo_json)
+    repo_obj = invoker.get_json_for_dir(TEST_DATA_PATH)
     assert len(repo_obj) == 1
 
     first_repo_obj = repo_obj[0]

--- a/xunit-autolabeler-v2/ast_parser/python_bootstrap.py
+++ b/xunit-autolabeler-v2/ast_parser/python_bootstrap.py
@@ -1,4 +1,4 @@
-# Copyright 2020 Google LLC. All Rights Reserved.
+# Copyright 2020 Google LLC.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -13,9 +13,20 @@
 # limitations under the License.
 
 
-# Add the parent 'ast_parser' module to PYTHONPATH
-# for consistency between Python and pytest
-#  Pytest root dir: '$REPO_ROOT/'
-#  Python root dir: '$REPO_ROOT/ast_parser'
+import os
 import sys
-sys.path.append('..')
+
+from python import invoker
+
+if len(sys.argv) != 2:
+    raise ValueError('Please specify exactly one [root] directory.')
+
+root_dir = sys.argv[1]
+output_file = os.path.join(root_dir, 'repo.json')
+
+json_out = invoker.get_json_for_dir(root_dir)
+with open(output_file, 'w') as f:
+    f.write(json_out + '\n')
+
+print(f'JSON written to: {output_file}')
+print('Do not move this file!')

--- a/xunit-autolabeler-v2/ast_parser/python_bootstrap.py
+++ b/xunit-autolabeler-v2/ast_parser/python_bootstrap.py
@@ -13,6 +13,7 @@
 # limitations under the License.
 
 
+import json
 import os
 import sys
 
@@ -22,11 +23,11 @@ if len(sys.argv) != 2:
     raise ValueError('Please specify exactly one [root] directory.')
 
 root_dir = sys.argv[1]
-output_file = os.path.join(root_dir, 'repo.json')
+output_path = os.path.join(root_dir, 'repo.json')
 
-json_out = invoker.get_json_for_dir(root_dir)
-with open(output_file, 'w') as f:
-    f.write(json_out + '\n')
+json_array = invoker.get_json_for_dir(root_dir)
+with open(output_path, 'w') as file:
+    json.dump(json_array, file)
 
-print(f'JSON written to: {output_file}')
+print(f'JSON written to: {output_path}')
 print('Do not move this file!')

--- a/xunit-autolabeler-v2/ast_parser/python_bootstrap.py
+++ b/xunit-autolabeler-v2/ast_parser/python_bootstrap.py
@@ -23,7 +23,7 @@ if len(sys.argv) != 2:
     raise ValueError('Please specify exactly one [root] directory.')
 
 root_dir = sys.argv[1]
-output_path = os.path.join(root_dir, 'repo.json')
+output_path = os.path.join(root_dir, 'polyglot_snippet_data.json')
 
 json_array = invoker.get_json_for_dir(root_dir)
 with open(output_path, 'w') as file:


### PR DESCRIPTION
These files allow users to invoke the Python-specific parser to generate a ~~`repo.json`~~ `polyglot_snippet_data.json` file.

This _should_ be the last Python-specific parser PR (for v1.0. at least). 🤞 