### PR TITLE
refactor(AST parser): use namedtuple in poly_parser instead of dict

### DIFF
--- a/xunit-autolabeler-v2/ast_parser/core/polyglot_drift_data.py
+++ b/xunit-autolabeler-v2/ast_parser/core/polyglot_drift_data.py
@@ -22,6 +22,9 @@ class PolyglotDriftData(NamedTuple):
     snippet data extracted from snippet source files
     for use by the second-stage "polyglot" parser.
     """
+    name: str
+    class_name: str
+    method_name: str
     source_path: str
     start_line: int
     end_line: int
@@ -30,22 +33,5 @@ class PolyglotDriftData(NamedTuple):
     test_methods: List[Tuple[str, str]] = []
     children: List[str] = []
 
-    @classmethod
-    def from_json_dict(cls, json_dict):
-        region_tags = json_dict.get('region_tags', [])
-        start_line = json_dict.get('start_line', None)
-        end_line = json_dict.get('end_line', None)
-        test_methods = json_dict.get('test_methods', [])
-        source_path = json_dict.get('source_path', [])
-        children = json_dict.get('children', [])
-        parser = json_dict.get('parser', None)
-
-        return cls(
-            source_path,
-            start_line,
-            end_line,
-            parser,
-            region_tags,
-            test_methods,
-            children
-        )
+    url: str = None
+    http_methods: List[str] = []

--- a/xunit-autolabeler-v2/ast_parser/core/polyglot_drift_data.py
+++ b/xunit-autolabeler-v2/ast_parser/core/polyglot_drift_data.py
@@ -1,0 +1,51 @@
+# Copyright 2020 Google LLC.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+
+from typing import List, NamedTuple, Tuple
+
+
+class PolyglotDriftData(NamedTuple):
+    """Struct for storing snippet metadata
+    This object stores language-agnostic ("polyglot")
+    snippet data extracted from snippet source files
+    for use by the second-stage "polyglot" parser.
+    """
+    source_path: str
+    start_line: int
+    end_line: int
+    parser: str
+    region_tags: List[str] = []
+    test_methods: List[Tuple[str, str]] = []
+    children: List[str] = []
+
+    @classmethod
+    def from_json_dict(cls, json_dict):
+        region_tags = json_dict.get('region_tags', [])
+        start_line = json_dict.get('start_line', None)
+        end_line = json_dict.get('end_line', None)
+        test_methods = json_dict.get('test_methods', [])
+        source_path = json_dict.get('source_path', [])
+        children = json_dict.get('children', [])
+        parser = json_dict.get('parser', None)
+
+        return cls(
+            source_path,
+            start_line,
+            end_line,
+            parser,
+            region_tags,
+            test_methods,
+            children
+        )

--- a/xunit-autolabeler-v2/ast_parser/core/polyglot_parser_test.py
+++ b/xunit-autolabeler-v2/ast_parser/core/polyglot_parser_test.py
@@ -17,6 +17,7 @@ import json
 import unittest
 from os import path
 
+from ast_parser.core import polyglot_drift_data as pdd
 from ast_parser.core import polyglot_parser
 
 
@@ -37,11 +38,17 @@ def _create_fixtures(test_folder, add_main=False):
     repo_json = path.join(test_folder_path, 'polyglot_snippet_data.json')
     source_path = path.join(test_folder_path, test_file)
 
-    source_methods = _parse_json(repo_json)
+    source_methods_json = _parse_json(repo_json)
+    source_methods = [pdd.PolyglotDriftData.from_json_dict(json_dict)
+                      for json_dict in source_methods_json]
+
     source_region_tags = \
         polyglot_parser.get_region_tag_regions(source_path)[0]
-    polyglot_parser.add_region_tags_to_methods(
-        source_methods, source_region_tags)
+    for idx, method in enumerate(source_methods):
+        source_methods[idx] = \
+            polyglot_parser.add_region_tags_to_method(
+                method, source_region_tags
+            )
 
     return source_methods
 
@@ -53,7 +60,7 @@ class PolyglotParserTests(unittest.TestCase):
         method = source_methods[0]
 
         # this should NOT contain 'main_method'
-        self.assertEqual(method['region_tags'], ['not_main'])
+        self.assertEqual(method.region_tags, ['not_main'])
 
     def test_region_tags_nested(self):
         source_methods = _create_fixtures('nested_tags')
@@ -61,10 +68,11 @@ class PolyglotParserTests(unittest.TestCase):
         method_1 = source_methods[0]
         method_2 = source_methods[1]
 
-        method_1['region_tags'].sort()
+        method_1.region_tags.sort()
+
         self.assertEqual(
-            method_1['region_tags'], ['nested_tag', 'root_tag'])
-        self.assertEqual(method_2['region_tags'], ['root_tag'])
+            method_1.region_tags, ['nested_tag', 'root_tag'])
+        self.assertEqual(method_2.region_tags, ['root_tag'])
 
     def test_handle_multi_block_region_tags(self):
         source_methods = _create_fixtures('nested_tags')
@@ -73,26 +81,26 @@ class PolyglotParserTests(unittest.TestCase):
         method_1 = source_methods[1]
         method_2 = source_methods[2]
 
-        self.assertEqual(method_1['region_tags'], ['root_tag'])
-        self.assertEqual(method_2['region_tags'], ['root_tag'])
+        self.assertEqual(method_1.region_tags, ['root_tag'])
+        self.assertEqual(method_2.region_tags, ['root_tag'])
 
     def test_flask_router_parser(self):
         source_methods = _create_fixtures('flask', True)
 
-        source_methods = [x for x in source_methods if
-                          x['parser'] == 'flask_router']
+        source_methods = [method for method in source_methods if
+                          method.parser == 'flask_router']
 
         method = source_methods[0]
-        self.assertEqual(method['region_tags'], ['sample_route'])
+        self.assertEqual(method.region_tags, ['sample_route'])
 
     def test_direct_invocation_parser(self):
         source_methods = _create_fixtures('http', True)
 
         method = source_methods[0]
-        assert 'functions_helloworld_get' in method['region_tags']
+        assert 'functions_helloworld_get' in method.region_tags
 
     def test_webapp2_parser(self):
         source_methods = _create_fixtures('webapp2', True)
 
         method = source_methods[-1]
-        self.assertEqual(method['region_tags'], ['sign_handler'])
+        self.assertEqual(method.region_tags, ['sign_handler'])

--- a/xunit-autolabeler-v2/ast_parser/core/polyglot_parser_test.py
+++ b/xunit-autolabeler-v2/ast_parser/core/polyglot_parser_test.py
@@ -39,7 +39,7 @@ def _create_fixtures(test_folder, add_main=False):
     source_path = path.join(test_folder_path, test_file)
 
     source_methods_json = _parse_json(repo_json)
-    source_methods = [pdd.PolyglotDriftData.from_json_dict(json_dict)
+    source_methods = [pdd.PolyglotDriftData(**json_dict)
                       for json_dict in source_methods_json]
 
     source_region_tags = \

--- a/xunit-autolabeler-v2/ast_parser/python/drift_data_tuple.py
+++ b/xunit-autolabeler-v2/ast_parser/python/drift_data_tuple.py
@@ -33,8 +33,7 @@ class DriftData(NamedTuple):
     start_line: int
     method_name: Optional[str] = None
     url: Optional[str] = None
-    flask_http_methods: List[str] = []
-    webapp2_http_method: Optional[str] = None
+    http_methods: List[str] = []
 
     # Properties set by source_parser.py
     source_path: Optional[str] = None

--- a/xunit-autolabeler-v2/ast_parser/python/source_parsers/flask_router.py
+++ b/xunit-autolabeler-v2/ast_parser/python/source_parsers/flask_router.py
@@ -75,7 +75,7 @@ def parse(
                 method.lineno,
                 method.name,
                 url,
-                flask_http_methods=http_methods
+                http_methods=http_methods
             )
         else:
             # Flask methods can match other parsers' method definitions

--- a/xunit-autolabeler-v2/ast_parser/python/source_parsers/flask_router_test.py
+++ b/xunit-autolabeler-v2/ast_parser/python/source_parsers/flask_router_test.py
@@ -97,7 +97,7 @@ class HttpMethodTests(unittest.TestCase):
 
         # method list is a hard-coded copy of:
         #   ast_parser.python.constants.FLASK_DEFAULT_METHODS
-        assert drift.flask_http_methods == ['get']
+        assert drift.http_methods == ['get']
 
     def test_detects_provided_http_methods(self):
         second_method = self.methods[-1]
@@ -106,7 +106,7 @@ class HttpMethodTests(unittest.TestCase):
 
         drift = second_method.drift
         assert drift.name == 'put_or_patch'
-        assert drift.flask_http_methods == ['put', 'patch']
+        assert drift.http_methods == ['put', 'patch']
 
 
 class MiscTests(unittest.TestCase):

--- a/xunit-autolabeler-v2/ast_parser/python/source_parsers/webapp2_router.py
+++ b/xunit-autolabeler-v2/ast_parser/python/source_parsers/webapp2_router.py
@@ -102,7 +102,7 @@ def parse(nodes: List[Any]) -> List[Any]:
                     handler_class.name,
                     'webapp2_router',
                     method.lineno,
-                    webapp2_http_method=method.name,
+                    http_methods=[method.name],
                     url=class_name_url_map[handler_class.name]
                 )
             else:

--- a/xunit-autolabeler-v2/ast_parser/python/source_parsers/webapp2_router_test.py
+++ b/xunit-autolabeler-v2/ast_parser/python/source_parsers/webapp2_router_test.py
@@ -51,15 +51,12 @@ class WebApp2RouterTests(unittest.TestCase):
         drift = first_method.drift
 
         assert drift.url == '/'
-        assert drift.webapp2_http_method == 'get'
+        assert drift.http_methods == ['get']
         assert drift.name == 'get'
 
         assert drift.class_name == 'ValidRoute'
         assert drift.parser == 'webapp2_router'
         assert drift.start_line == 36
-
-        # Make sure flask_http_methods wasn't accidentally set
-        assert drift.flask_http_methods == []
 
     def test_ignores_WSGIApplication_nodes_without_webapp2(self):
         assert 'RouteWithoutProperSubclass' not in self.class_names

--- a/xunit-autolabeler-v2/ast_parser/python/test_parser.py
+++ b/xunit-autolabeler-v2/ast_parser/python/test_parser.py
@@ -202,10 +202,10 @@ def store_tests_on_methods(
         if drift.parser == 'direct_invocation':
             keys = [(drift.class_name, drift.method_name)]
         elif drift.parser == 'webapp2_router':
-            keys = [(drift.webapp2_http_method, drift.url)]
+            keys = [(drift.http_methods[0], drift.url)]
         elif drift.parser == 'flask_router':
             keys = [(http_method, drift.url)
-                    for http_method in drift.flask_http_methods]
+                    for http_method in drift.http_methods]
 
         new_test_methods = list(method.drift.test_methods)  # deep copy
         for key in keys:


### PR DESCRIPTION
Groundwork for the `analyze.py` stage (hopefully the 3rd-to-last PR before 1.0 🎉 )

N.B: this PR **conflicts with #54**. Proposed merge process:
1) Merge this PR (into `main`) first
2) Remove `polyglot_drift_data.py` file from #54 (file was required for that PR's tests to pass)
3) Rebase #54 on top of "new" `main` branch (using force-push)
4) Merge this into `main`.