### PR TITLE
chore(AST parser): bugfixes for python-docs-samples

### DIFF
--- a/ci-cd/p3_temp/test_ast_parser.sh
+++ b/ci-cd/p3_temp/test_ast_parser.sh
@@ -29,7 +29,7 @@ pip install --user -r requirements-dev.txt
 ./python_bootstrap.py core/test_data/cli/dotfile_test/.dotfile
 ./python_bootstrap.py core/test_data/parser
 ./python_bootstrap.py core/test_data/parser/edge_cases
-./python_bootstrap.py core/test_data/parser/edge_cases
+./python_bootstrap.py core/test_data/parser/exclude_tags
 ./python_bootstrap.py core/test_data/parser/flask
 ./python_bootstrap.py core/test_data/parser/http
 ./python_bootstrap.py core/test_data/parser/nested_tags

--- a/xunit-autolabeler-v2/ast_parser/core/constants.py
+++ b/xunit-autolabeler-v2/ast_parser/core/constants.py
@@ -17,7 +17,7 @@ import re
 from frozendict import frozendict
 
 
-REGION_TAG_ONLY_REGEX = re.compile(r'(?<=\s)+\w+(?=])')
+REGION_TAG_ONLY_REGEX = re.compile(r'(?<=\s)+(\w|-)+(?=])')
 
 IGNORED_METHOD_NAMES = (
     'run_command',

--- a/xunit-autolabeler-v2/ast_parser/core/constants_test.py
+++ b/xunit-autolabeler-v2/ast_parser/core/constants_test.py
@@ -1,0 +1,42 @@
+# Copyright 2020 Google LLC. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from ast_parser.core import constants
+
+import pytest
+
+
+@pytest.mark.parametrize(
+    'region_tag_line,expected',
+    [
+        ('[START foo]', 'foo'),
+        ('[END foo]', 'foo'),
+        ('[START foo_bar]', 'foo_bar'),
+        ('[START foo-bar]', 'foo-bar'),
+        ('// [START foo]', 'foo'),
+        ('# [START foo]', 'foo')
+    ],
+    ids=[
+        'basic_start_tag',
+        'basic_end_tag',
+        'underscore_tag',
+        'hyphen_tag',
+        'slash_comment',
+        'pound_comment'
+    ]
+)
+def test_detects_region_tag(region_tag_line, expected):
+    result = constants.REGION_TAG_ONLY_REGEX.search(region_tag_line)
+    assert result is not None
+    assert expected in result.group(0)

--- a/xunit-autolabeler-v2/ast_parser/core/polyglot_parser.py
+++ b/xunit-autolabeler-v2/ast_parser/core/polyglot_parser.py
@@ -98,11 +98,19 @@ def get_region_tag_regions(
         line_text: str = line[1]
 
         tag = constants.REGION_TAG_ONLY_REGEX.search(line_text).group(0)
+
         return (line_num + 1, tag)  # +1 = convert to 0-indexed
 
     with open(source_path, 'r') as file:
+        file_lines = file.readlines()
+
+        # Remove _EXCLUDE tags
+        file_lines = [line for line in file_lines
+                      if '[START_EXCLUDE' not in line
+                      and '[END_EXCLUDE' not in line]
+
         content_lines = [(idx, line_text) for idx, line_text in
-                         enumerate(file.readlines())]
+                         enumerate(file_lines)]
 
         start_tag_lines = [line_tuple for line_tuple in content_lines
                            if ' [START' in line_tuple[1]]

--- a/xunit-autolabeler-v2/ast_parser/core/polyglot_parser_test.py
+++ b/xunit-autolabeler-v2/ast_parser/core/polyglot_parser_test.py
@@ -104,3 +104,9 @@ class PolyglotParserTests(unittest.TestCase):
 
         method = source_methods[-1]
         self.assertEqual(method.region_tags, ['sign_handler'])
+
+    def test_ignores_exclude_tags(self):
+        source_methods = _create_fixtures('exclude_tags', True)
+
+        # make sure the file was parsed properly
+        assert len(source_methods) == 1

--- a/xunit-autolabeler-v2/ast_parser/core/polyglot_parser_test.py
+++ b/xunit-autolabeler-v2/ast_parser/core/polyglot_parser_test.py
@@ -109,4 +109,4 @@ class PolyglotParserTests(unittest.TestCase):
         source_methods = _create_fixtures('exclude_tags', True)
 
         # make sure the file was parsed properly
-        assert len(source_methods) == 1
+        assert len(source_methods) == 2

--- a/xunit-autolabeler-v2/ast_parser/core/test_data/parser/exclude_tags/exclude_tags_main.py
+++ b/xunit-autolabeler-v2/ast_parser/core/test_data/parser/exclude_tags/exclude_tags_main.py
@@ -1,0 +1,24 @@
+# Copyright 2020 Google LLC.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+
+# [START main_method]
+def main():
+    return 'main method'
+# [START_EXCLUDE]
+
+# [END_EXCLUDE]
+def not_main():
+    return 'not main'
+# [END main_method]

--- a/xunit-autolabeler-v2/ast_parser/core/test_data/parser/exclude_tags/exclude_tags_main.py
+++ b/xunit-autolabeler-v2/ast_parser/core/test_data/parser/exclude_tags/exclude_tags_main.py
@@ -14,11 +14,12 @@
 
 
 # [START main_method]
-def main():
-    return 'main method'
+def included():
+    return 'included method one'
 # [START_EXCLUDE]
 
+
+def also_included():
+    return 'also included method'
 # [END_EXCLUDE]
-def not_main():
-    return 'not main'
 # [END main_method]

--- a/xunit-autolabeler-v2/ast_parser/core/test_data/parser/exclude_tags/exclude_tags_main.py
+++ b/xunit-autolabeler-v2/ast_parser/core/test_data/parser/exclude_tags/exclude_tags_main.py
@@ -13,7 +13,7 @@
 # limitations under the License.
 
 
-# [START main_method]
+# [START included]
 def included():
     return 'included method one'
 # [START_EXCLUDE]
@@ -22,4 +22,4 @@ def included():
 def also_included():
     return 'also included method'
 # [END_EXCLUDE]
-# [END main_method]
+# [END included]

--- a/xunit-autolabeler-v2/ast_parser/python/source_parser.py
+++ b/xunit-autolabeler-v2/ast_parser/python/source_parser.py
@@ -83,19 +83,22 @@ def _get_ending_line(expr: Any) -> int:
         if hasattr(final_stmt, 'lineno'):
             highest_line_no = final_stmt.lineno
 
-        if hasattr(final_stmt, 'body'):
+        body_is_valid = hasattr(final_stmt, 'body') and final_stmt.body
+        if body_is_valid and isinstance(final_stmt.body, list):
             final_stmt = final_stmt.body[-1]
+        elif body_is_valid:
+            final_stmt = final_stmt.body
         elif hasattr(final_stmt, 'exc'):
             final_stmt = final_stmt.exc
-        elif hasattr(final_stmt, 'args'):
+        elif hasattr(final_stmt, 'args') and final_stmt.args:
             final_stmt = final_stmt.args[-1]
-        elif hasattr(final_stmt, 'elts'):
+        elif hasattr(final_stmt, 'elts') and final_stmt.elts:
             final_stmt = final_stmt.elts[-1]
-        elif hasattr(final_stmt, 'generators'):
+        elif hasattr(final_stmt, 'generators') and final_stmt.generators:
             final_stmt = final_stmt.generators[-1]
         elif hasattr(final_stmt, 'iter'):
             final_stmt = final_stmt.iter
-        elif hasattr(final_stmt, 'values'):
+        elif hasattr(final_stmt, 'values') and final_stmt.values:
             final_stmt = final_stmt.values[-1]
         elif hasattr(final_stmt, 'value'):
             # some (but not all) value attributes have
@@ -147,6 +150,14 @@ def get_top_level_methods(source_path: str) -> List[Any]:
         #  we don't want to "break the build".)
         sys.stderr.write(
             f'WARNING: could not read file: {source_path}\n')
+        sys.stderr.write(
+            f'\t{str(err)}\n')
+
+        return []
+    except SyntaxError as err:
+        # Fail gracefully if a file doesn't use py3-compliant syntax.
+        sys.stderr.write(
+            f'WARNING: could not parse file: {source_path}\n')
         sys.stderr.write(
             f'\t{str(err)}\n')
 

--- a/xunit-autolabeler-v2/ast_parser/python/source_parser_test.py
+++ b/xunit-autolabeler-v2/ast_parser/python/source_parser_test.py
@@ -131,6 +131,109 @@ class GetTopLevelMethodsTest(unittest.TestCase):
         assert drift.end_line > drift.start_line
 
 
+class GetEndingLineNumberTest(unittest.TestCase):
+    def _clear_fake_elem(self, lineno):
+        fake_elem = MagicMock(autospec=False)
+
+        del fake_elem.args
+        del fake_elem.body
+        del fake_elem.elts
+        del fake_elem.exc
+        del fake_elem.expr
+        del fake_elem.generators
+        del fake_elem.iter
+        del fake_elem.value
+        del fake_elem.values
+
+        fake_elem.lineno = lineno
+
+        return fake_elem
+
+    def test_handles_body_as_list(self):
+        elem = self._clear_fake_elem(1)
+        elem.body = [self._clear_fake_elem(2), self._clear_fake_elem(3)]
+
+        assert source_parser._get_ending_line(elem) == 3
+
+    def test_handles_empty_body_list(self):
+        elem = self._clear_fake_elem(2)
+        elem.body = []
+
+        assert source_parser._get_ending_line(elem) == 2
+
+    def test_handles_body_as_element(self):
+        elem = self._clear_fake_elem(1)
+        elem.body = self._clear_fake_elem(2)
+
+        assert source_parser._get_ending_line(elem) == 2
+
+    def test_handles_exc(self):
+        elem = self._clear_fake_elem(1)
+        elem.exc = self._clear_fake_elem(2)
+
+        assert source_parser._get_ending_line(elem) == 2
+
+    def test_handles_args(self):
+        elem = self._clear_fake_elem(1)
+        elem.args = [self._clear_fake_elem(2), self._clear_fake_elem(3)]
+
+        assert source_parser._get_ending_line(elem) == 3
+
+    def test_handles_empty_args(self):
+        elem = self._clear_fake_elem(1)
+        elem.args = []
+
+        assert source_parser._get_ending_line(elem) == 1
+
+    def test_handles_elts(self):
+        elem = self._clear_fake_elem(1)
+        elem.elts = [self._clear_fake_elem(2), self._clear_fake_elem(3)]
+
+        assert source_parser._get_ending_line(elem) == 3
+
+    def test_handles_empty_elts(self):
+        elem = self._clear_fake_elem(1)
+        elem.elts = []
+
+        assert source_parser._get_ending_line(elem) == 1
+
+    def test_handles_generators(self):
+        elem = self._clear_fake_elem(1)
+        elem.generators = [self._clear_fake_elem(2), self._clear_fake_elem(3)]
+
+        assert source_parser._get_ending_line(elem) == 3
+
+    def test_handles_empty_generators(self):
+        elem = self._clear_fake_elem(1)
+        elem.generators = []
+
+        assert source_parser._get_ending_line(elem) == 1
+
+    def test_handles_iter(self):
+        elem = self._clear_fake_elem(1)
+        elem.iter = self._clear_fake_elem(2)
+
+        assert source_parser._get_ending_line(elem) == 2
+
+    def test_handles_values(self):
+        elem = self._clear_fake_elem(1)
+        elem.values = [self._clear_fake_elem(2), self._clear_fake_elem(3)]
+
+        assert source_parser._get_ending_line(elem) == 3
+
+    def test_handles_empty_values(self):
+        elem = self._clear_fake_elem(1)
+        elem.values = []
+
+        assert source_parser._get_ending_line(elem) == 1
+
+    def test_handles_value(self):
+        elem = self._clear_fake_elem(1)
+        elem.value = self._clear_fake_elem(2)
+
+        assert source_parser._get_ending_line(elem) == 2
+
+
 def test_warns_on_invalid_file(capsys):
     # This test cannot be within a class, since it uses the capsys fixture
     invalid_methods = source_parser.get_top_level_methods('foo.bar')

--- a/xunit-autolabeler-v2/ast_parser/python_bootstrap.py
+++ b/xunit-autolabeler-v2/ast_parser/python_bootstrap.py
@@ -1,4 +1,5 @@
-#!/usr/bin/env python3
+#!/usr/bin/env python3.8
+# ^ Use python 3.8 since Pip isn't configured for newer versions (3.9+)
 
 # Copyright 2020 Google LLC.
 #

--- a/xunit-autolabeler-v2/ast_parser/python_bootstrap.py
+++ b/xunit-autolabeler-v2/ast_parser/python_bootstrap.py
@@ -1,5 +1,4 @@
-#!/usr/bin/env python3.8
-# ^ Use python 3.8 since Pip isn't configured for newer versions (3.9+)
+#!/usr/bin/env python3
 
 # Copyright 2020 Google LLC.
 #


### PR DESCRIPTION
**N.B:** ignoring `_EXCLUDE` tags outright for snippet-test correlation purposes is a bit of a hack, but is
a) easier than trying to figure out what the corresponding region tags are
b) fairly low-impact (IMO), as these tags aren't common^

^: The more common strategy is to use multiple sets of `START` and `END` tags, which _is_ taken into account by the snippet correlation system. (In other words - if this causes bugs, we can simply replace the `_EXCLUDE` tags with their appropriate `START/END` counterparts.)