### PR TITLE
feat(AST parser): add support for jobs API

### DIFF
--- a/ci-cd/p3_temp/test_ast_parser.sh
+++ b/ci-cd/p3_temp/test_ast_parser.sh
@@ -33,6 +33,7 @@ pip install --user -r requirements-dev.txt
 ./python_bootstrap.py core/test_data/parser/flask
 ./python_bootstrap.py core/test_data/parser/http
 ./python_bootstrap.py core/test_data/parser/nested_tags
+./python_bootstrap.py core/test_data/parser/snippet_invocation_methods
 ./python_bootstrap.py core/test_data/parser/webapp2
 ./python_bootstrap.py core/test_data/parser/duplicate_region_tag
 ./python_bootstrap.py core/test_data/yaml

--- a/xunit-autolabeler-v2/ast_parser/core/analyze.py
+++ b/xunit-autolabeler-v2/ast_parser/core/analyze.py
@@ -19,6 +19,7 @@ from typing import Dict, List, Set, Tuple
 
 from ast_parser.lib import constants as lib_constants
 
+from . import constants
 from . import polyglot_drift_data as pdd
 from . import polyglot_parser, yaml_utils
 
@@ -125,12 +126,22 @@ def _dedupe_source_methods(
     Returns:
         A de-duped list of (snippet) source methods
     """
-    source_methods_deduped = {
-        ','.join(sorted(method.region_tags)): method
-        for method in source_methods
-    }.values()
+    source_method_keys = set()
+    deduped_methods = []
 
-    return list(source_methods_deduped)
+    for method in source_methods:
+        if method.name in constants.SNIPPET_INVOCATION_METHODS:
+            key = method.source_path + ',' + method.name
+        else:
+            key = ','.join(sorted(method.region_tags))
+
+        if key in source_method_keys:
+            continue
+
+        source_method_keys.add(key)
+        deduped_methods.append(method)
+
+    return list(deduped_methods)
 
 
 def _store_tests_on_methods(
@@ -238,7 +249,10 @@ def analyze_json(
         grep_tags = grep_tags.union(grep_tag_names)
         ignored_tags = ignored_tags.union(ignored_tag_names)
 
-    source_methods = [method for method in tuple_methods if method.region_tags]
+    source_methods = [method for method in tuple_methods
+                      if method.region_tags or
+                      method.name in constants.SNIPPET_INVOCATION_METHODS]
+
     source_methods = _dedupe_source_methods(source_methods)
 
     _store_tests_on_methods(source_methods, test_method_map)

--- a/xunit-autolabeler-v2/ast_parser/core/analyze.py
+++ b/xunit-autolabeler-v2/ast_parser/core/analyze.py
@@ -131,7 +131,7 @@ def _dedupe_source_methods(
 
     for method in source_methods:
         if method.name in constants.SNIPPET_INVOCATION_METHODS:
-            key = method.source_path + ',' + method.name
+            key = f'{method.source_path},{method.name}'
         else:
             key = ','.join(sorted(method.region_tags))
 

--- a/xunit-autolabeler-v2/ast_parser/core/analyze_smoke_test.py
+++ b/xunit-autolabeler-v2/ast_parser/core/analyze_smoke_test.py
@@ -15,7 +15,7 @@
 import os
 import unittest
 
-from ast_parser.core import analyze
+from ast_parser.core import analyze, constants
 
 import mock
 
@@ -70,6 +70,27 @@ class AnalyzeJsonMiscTests(unittest.TestCase):
         tag_sets = [method.region_tags for method in source_methods]
 
         assert sum(tag_set == ['not_main'] for tag_set in tag_sets) == 1
+
+    def test_handle_snippet_invocation_methods(self):
+        test_dir = os.path.join(_TEST_DIR, 'snippet_invocation_methods')
+        analyze_result = analyze.analyze_json(
+            os.path.join(test_dir, 'polyglot_snippet_data.json'),
+            test_dir
+        )
+        _, _, _, source_methods = analyze_result
+
+        assert len(source_methods) == 3
+
+        # make sure the methods were parsed
+        # (in the right order, to make testing easier)
+        assert source_methods[0].name == 'some_method'
+        assert source_methods[1].name == 'another_method'
+        assert source_methods[2].name in constants.SNIPPET_INVOCATION_METHODS
+
+        # make sure these methods' tests were detected
+        print(source_methods[0])
+        assert source_methods[0].test_methods
+        assert source_methods[1].test_methods
 
 
 class AnalyzeJsonMockCallTests(unittest.TestCase):

--- a/xunit-autolabeler-v2/ast_parser/core/analyze_smoke_test.py
+++ b/xunit-autolabeler-v2/ast_parser/core/analyze_smoke_test.py
@@ -88,7 +88,6 @@ class AnalyzeJsonMiscTests(unittest.TestCase):
         assert source_methods[2].name in constants.SNIPPET_INVOCATION_METHODS
 
         # make sure these methods' tests were detected
-        print(source_methods[0])
         assert source_methods[0].test_methods
         assert source_methods[1].test_methods
 

--- a/xunit-autolabeler-v2/ast_parser/core/analyze_test.py
+++ b/xunit-autolabeler-v2/ast_parser/core/analyze_test.py
@@ -93,12 +93,12 @@ class ProcessRegionTagsTest(unittest.TestCase):
 
 
 class DedupeSourceMethodsTest(unittest.TestCase):
-    def _create_drift_data(self, region_tags):
+    def _create_drift_data(self, region_tags, name=None):
         return pdd.PolyglotDriftData(
-            name=None,
+            name=name,
             class_name=None,
             method_name=None,
-            source_path=None,
+            source_path='',
             start_line=None,
             end_line=None,
             parser=None,
@@ -120,6 +120,22 @@ class DedupeSourceMethodsTest(unittest.TestCase):
         ]
 
         assert len(analyze._dedupe_source_methods(methods)) == 1
+
+    def test_keeps_snippet_invocation_methods_without_tags(self):
+        method_name = 'run_sample'
+        methods = [
+            self._create_drift_data(['a', 'b']),
+            self._create_drift_data(['b', 'a']),
+
+            # this method is considered a 'snippet invocation method'
+            # these methods aren't required to have region tags
+            self._create_drift_data([], method_name),
+        ]
+
+        results = analyze._dedupe_source_methods(methods)
+
+        assert len(results) == 2
+        assert results[1].name == method_name
 
 
 class StoreTestsOnMethodsTests(unittest.TestCase):

--- a/xunit-autolabeler-v2/ast_parser/core/constants.py
+++ b/xunit-autolabeler-v2/ast_parser/core/constants.py
@@ -61,3 +61,6 @@ REQUIRED_KEY_VALUES = frozendict({
 
 # region tags that don't uniquely identify a sample
 IGNORED_REGION_TAGS = ('app', 'all')
+
+# names of methods used to invoke snippets from within a source file
+SNIPPET_INVOCATION_METHODS = ('run_sample',)

--- a/xunit-autolabeler-v2/ast_parser/core/polyglot_parser.py
+++ b/xunit-autolabeler-v2/ast_parser/core/polyglot_parser.py
@@ -35,6 +35,7 @@ def add_children_drift_data(
     Note:
         This method should be called once all other parsing is complete
     """
+    recursed_nodes = set()
 
     def _recursor(method: pdd.PolyglotDriftData) -> pdd.PolyglotDriftData:
         """Recursively traverses through a snippet method's child methods
@@ -45,15 +46,18 @@ def add_children_drift_data(
         Returns:
             An updated PolyglotDriftData object
         """
-        for child in method.children:
-            child_methods = [child_method for child_method in source_methods
-                             if 'name' in child_method]
-            child_methods = [child_method for child_method in child_methods
-                             if child == child_method['name']]
 
-            # prevent infinite loops
-            child_methods = [child_method for child_method in child_methods
-                             if child_method['name'] != method['name']]
+        # Prevent infinite loops
+        method_key = (method.name, method.class_name, method.source_path)
+        if method_key in recursed_nodes:
+            return
+        recursed_nodes.add(method_key)
+
+        for child in method.children:
+            child_methods = [
+                child_method for child_method in source_methods if
+                child_method.name and child == child_method.name
+            ]
 
             if child_methods:
                 child_method = child_methods[0]
@@ -64,6 +68,34 @@ def add_children_drift_data(
 
         method.region_tags = list(set(method.region_tags))
         method.test_methods = list(set(method.test_methods))
+
+    """
+    EDGE CASE:
+        Some snippets (e.g. Python jobs API) are wrapped in a separate
+        "snippet invocation method" (e.g. "run_sample"), that itself is
+        invoked within the tests.
+
+    SOLUTION:
+        Move snippet-invocation method tests to their invoked [child] methods
+        (This *cannot* be done with the child-labeling system, as that looks
+         for tests in the child methods - *not* the parent ones!)
+    """
+    for method in source_methods:
+        if method.name in constants.SNIPPET_INVOCATION_METHODS:
+            for child_name in method.children:
+                child_methods = [
+                    child_method for child_method in source_methods
+                    if child_method.name == child_name and
+                    method.source_path == child_method.source_path
+                ]
+
+                if child_methods:
+                    child_methods[0].test_methods.extend(method.test_methods)
+
+            # Remove direct children of snippet invocation methods
+            # (Since the invocation method's test data was propagated to them)
+            method.children = []
+            method.test_methods = []
 
     for method in source_methods:
         _recursor(method)

--- a/xunit-autolabeler-v2/ast_parser/core/test_data/parser/snippet_invocation_methods/main.py
+++ b/xunit-autolabeler-v2/ast_parser/core/test_data/parser/snippet_invocation_methods/main.py
@@ -1,0 +1,31 @@
+# Copyright 2020 Google LLC.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+
+# [START some_method]
+def some_method():
+    return 'some method'
+# [END some_method]
+
+
+# [START another_method]
+def another_method():
+    return 'another method'
+# [END another_method]
+
+
+def run_sample():
+    a = some_method()
+    b = another_method()
+    return a + ' ' + b

--- a/xunit-autolabeler-v2/ast_parser/core/test_data/parser/snippet_invocation_methods/main_test.py
+++ b/xunit-autolabeler-v2/ast_parser/core/test_data/parser/snippet_invocation_methods/main_test.py
@@ -1,0 +1,20 @@
+# Copyright 2020 Google LLC.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+
+import main
+
+
+def test_methods():
+    assert main.run_sample() == 'some method another method'


### PR DESCRIPTION
This PR addresses the [jobs API samples'](https://github.com/GoogleCloudPlatform/python-docs-samples/tree/master/jobs/v3/api_client) snippets not being matched to their tests.

(Instead of tests directly invoking snippets, they invoke a `run_sample` method _that then invokes the tests_. Since the "_child_ method (i.e. tests in _invoked_ methods) resolving system" can't handle _parent_ methods (i.e. tests in _invoker_ methods), we add some custom logic to the core parser to deal with this edge case.)