### PR TITLE
chore(AST parser): detect snippets called in try-finally + method bodies

### DIFF
--- a/xunit-autolabeler-v2/ast_parser/core/constants.py
+++ b/xunit-autolabeler-v2/ast_parser/core/constants.py
@@ -19,6 +19,8 @@ from frozendict import frozendict
 
 REGION_TAG_ONLY_REGEX = re.compile(r'(?<=\s)+(\w|-)+(?=])')
 
+BODY_IS_ARRAY_REGEX = re.compile('ast.(With|For|Try|FunctionDef)')
+
 IGNORED_METHOD_NAMES = (
     'run_command',
     'parse_command_line_args',

--- a/xunit-autolabeler-v2/ast_parser/python/invoker.py
+++ b/xunit-autolabeler-v2/ast_parser/python/invoker.py
@@ -51,7 +51,7 @@ def get_json_for_dir(root_dir: str) -> Dict[str, Union[List, Dict]]:
     test_files = [file for file in python_files
                   if constants.TEST_FILE_MARKER in file]
 
-    test_method_map: Dict[Tuple[str, str], List[Tuple[str, str]]] = dict()
+    test_method_map: Dict[Tuple[str, str], List[Tuple[str, str]]] = {}
     for file in test_files:
         tests = _parse_test(file, source_methods)
         for test_keys, test_value in tests.items():

--- a/xunit-autolabeler-v2/ast_parser/python/invoker.py
+++ b/xunit-autolabeler-v2/ast_parser/python/invoker.py
@@ -15,7 +15,7 @@
 
 import dataclasses
 import os
-from typing import Any, Dict, List
+from typing import Any, Dict, List, Tuple, Union
 
 from ast_parser.lib import constants as lib_constants, file_utils
 
@@ -27,14 +27,18 @@ def _parse_source(source_path: str) -> List[Any]:
     return [method for method in source_methods]
 
 
-def _parse_test(test_path: str, source_methods: List[Any]) -> None:
+def _parse_test(
+    test_path: str,
+    source_methods: List[Any]
+) -> Dict[Tuple[str, str], List[Tuple[str, str]]]:
     test_methods = test_parser.get_test_methods(test_path)
-    test_method_map = test_parser.get_test_key_to_snippet_map(test_methods)
+    test_method_map: Dict[Tuple[str, str], List[Tuple[str, str]]] = (
+        test_parser.get_test_key_to_snippet_map(test_methods))
 
     return test_method_map
 
 
-def get_json_for_dir(root_dir: str) -> List[Dict]:
+def get_json_for_dir(root_dir: str) -> Dict[str, Union[List, Dict]]:
     python_files = file_utils.get_python_files(root_dir)
 
     source_methods = []
@@ -47,7 +51,7 @@ def get_json_for_dir(root_dir: str) -> List[Dict]:
     test_files = [file for file in python_files
                   if constants.TEST_FILE_MARKER in file]
 
-    test_method_map = dict()
+    test_method_map: Dict[Tuple[str, str], List[Tuple[str, str]]] = dict()
     for file in test_files:
         tests = _parse_test(file, source_methods)
         for test_keys, test_value in tests.items():

--- a/xunit-autolabeler-v2/ast_parser/python/source_parsers/flask_router_test.py
+++ b/xunit-autolabeler-v2/ast_parser/python/source_parsers/flask_router_test.py
@@ -73,7 +73,11 @@ class DecoratorTests(unittest.TestCase):
 
         assert drift.parser == 'flask_router'
         assert drift.class_name == 'test_flask_class'
-        assert drift.start_line == 47
+
+        # This differs between py3.7 and py3.8
+        # The difference doesn't affect parser logic,
+        # so we allow both possible results.
+        assert drift.start_line in [47, 48]
 
         # Don't check http_methods here
         # (covered in HttpMethodTests)

--- a/xunit-autolabeler-v2/ast_parser/python/source_parsers/flask_router_test.py
+++ b/xunit-autolabeler-v2/ast_parser/python/source_parsers/flask_router_test.py
@@ -74,9 +74,12 @@ class DecoratorTests(unittest.TestCase):
         assert drift.parser == 'flask_router'
         assert drift.class_name == 'test_flask_class'
 
-        # This differs between py3.7 and py3.8
+        # This differs between py3.8 and py3.9
         # The difference doesn't affect parser logic,
         # so we allow both possible results.
+        #
+        # Likely caused by
+        # https://bugs.python.org/issue34822
         assert drift.start_line in [47, 48]
 
         # Don't check http_methods here

--- a/xunit-autolabeler-v2/ast_parser/python/source_parsers/flask_router_test.py
+++ b/xunit-autolabeler-v2/ast_parser/python/source_parsers/flask_router_test.py
@@ -73,7 +73,7 @@ class DecoratorTests(unittest.TestCase):
 
         assert drift.parser == 'flask_router'
         assert drift.class_name == 'test_flask_class'
-        assert drift.start_line == 48
+        assert drift.start_line == 47
 
         # Don't check http_methods here
         # (covered in HttpMethodTests)

--- a/xunit-autolabeler-v2/ast_parser/python/test_data/parser/function_wrapped_calls/function_wrapped.py
+++ b/xunit-autolabeler-v2/ast_parser/python/test_data/parser/function_wrapped_calls/function_wrapped.py
@@ -1,0 +1,19 @@
+# Copyright 2020 Google LLC.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+
+# [START main_method]
+def main():
+    return 'main method'
+# [END main_method]

--- a/xunit-autolabeler-v2/ast_parser/python/test_data/parser/function_wrapped_calls/function_wrapped_test.py
+++ b/xunit-autolabeler-v2/ast_parser/python/test_data/parser/function_wrapped_calls/function_wrapped_test.py
@@ -1,0 +1,22 @@
+# Copyright 2020 Google LLC. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import function_wrapped
+
+
+def test_function_wrapped():
+    def foo():
+        assert function_wrapped.main() == 'main method'
+
+    foo()

--- a/xunit-autolabeler-v2/ast_parser/python/test_data/parser/try_finally/try_finally.py
+++ b/xunit-autolabeler-v2/ast_parser/python/test_data/parser/try_finally/try_finally.py
@@ -1,0 +1,31 @@
+# Copyright 2020 Google LLC.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+
+# [START try_method]
+def try_method():
+    return 'try method'
+# [END try_method]
+
+
+# [START final_method]
+def final_method():
+    return 'final method'
+# [END final_method]
+
+
+# [START final_method]
+def exception_handler():
+    return 'exception handler'
+# [END final_method]

--- a/xunit-autolabeler-v2/ast_parser/python/test_data/parser/try_finally/try_finally_test.py
+++ b/xunit-autolabeler-v2/ast_parser/python/test_data/parser/try_finally/try_finally_test.py
@@ -1,0 +1,27 @@
+# Copyright 2020 Google LLC. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import try_finally
+
+
+def test_try_finally():
+    try:
+        assert try_finally.try_method() == 'try method'
+    except Exception:
+        # This should NOT be detected by the AST parser.
+        # (Exceptions should represent unintended behavior,
+        #  and as such are deliberately ignored.)
+        assert try_finally.exception_handler() == 'exception handler'
+    finally:
+        assert try_finally.final_method() == 'final method'

--- a/xunit-autolabeler-v2/ast_parser/python/test_parser.py
+++ b/xunit-autolabeler-v2/ast_parser/python/test_parser.py
@@ -150,15 +150,19 @@ def get_test_key_to_snippet_map(
             results += __recursor__(expr.test.left)
             return results
 
-        if '.With' in type_str or '.For' in type_str:
-            results = []
+        results = []
+        if hasattr(expr, 'finalbody'):
+            # Used in try-catch-finally statements
+            for subexpr in expr.finalbody:
+                results += [subexpr for subexpr
+                            in __recursor__(subexpr) if subexpr]
+
+        if constants.BODY_IS_ARRAY_REGEX.search(type_str):
             for subexpr in expr.body:
                 results += [subexpr for subexpr
                             in __recursor__(subexpr) if subexpr]
 
-            return results  # may contain duplicates
-
-        return []
+        return results  # may contain duplicates
 
     for method in test_methods:
         for subexpr in method.body:

--- a/xunit-autolabeler-v2/ast_parser/python/test_parser.py
+++ b/xunit-autolabeler-v2/ast_parser/python/test_parser.py
@@ -90,7 +90,7 @@ def get_test_methods(test_path: str) -> List[Any]:
 
 def get_test_key_to_snippet_map(
     test_methods: List[Any]
-) -> Dict[Tuple[str, str], Tuple[str, str]]:
+) -> Dict[Tuple[str, str], List[Tuple[str, str]]]:
     """Map the supplied test methods to their relevant 'test keys'
 
     Test keys are tuples that a) identify a particular snippet and b)
@@ -104,7 +104,7 @@ def get_test_key_to_snippet_map(
     Returns: a mapping between test keys and their corresponding
              test data (file paths and method names)
     """
-    test_to_method_key_map = {}
+    test_to_method_key_map: Dict[Tuple[str, str], List[Tuple[str, str]]] = {}
 
     def __recursor__(expr: Any) -> List[drift_test.DriftTest]:
         """Recursively find test keys within an expression

--- a/xunit-autolabeler-v2/ast_parser/python/test_parser_test.py
+++ b/xunit-autolabeler-v2/ast_parser/python/test_parser_test.py
@@ -112,7 +112,7 @@ class GetTestToMethodMapSmokeTests(unittest.TestCase):
     def test_handles_function_wrapped_calls(self):
         path = os.path.join(
             TEST_DATA_DIR,
-            'parser/function_wrapped/function_wrapped_test.py'
+            'parser/function_wrapped_calls/function_wrapped_test.py'
         )
 
         test_methods = test_parser.get_test_methods(path)

--- a/xunit-autolabeler-v2/ast_parser/python/test_parser_test.py
+++ b/xunit-autolabeler-v2/ast_parser/python/test_parser_test.py
@@ -16,6 +16,8 @@
 import os
 import unittest
 
+import pytest
+
 from . import test_parser
 
 
@@ -106,3 +108,50 @@ class GetTestToMethodMapSmokeTests(unittest.TestCase):
         entry = test_map[key]
         assert len(entry) == 1
         assert entry[0] == (path, 'test_not_main')
+
+    def test_handles_function_wrapped_calls(self):
+        path = os.path.join(
+            TEST_DATA_DIR,
+            'parser/function_wrapped/function_wrapped_test.py'
+        )
+
+        test_methods = test_parser.get_test_methods(path)
+        test_map = test_parser.get_test_key_to_snippet_map(test_methods)
+
+        key = ('function_wrapped', 'main')
+
+        assert key in test_map
+
+        entry = test_map[key]
+        assert len(entry) == 1
+        assert entry[0] == (path, 'test_function_wrapped')
+
+
+class GetTestToMethodMapTryFinallyTests(unittest.TestCase):
+    @pytest.fixture(autouse=True)
+    def _test_methods(self):
+        self.path = os.path.join(
+            TEST_DATA_DIR,
+            'parser/try_finally/try_finally_test.py'
+        )
+        self.test_methods = test_parser.get_test_methods(self.path)
+        self.test_map = (
+            test_parser.get_test_key_to_snippet_map(self.test_methods))
+
+    def test_finds_tests_in_try_clauses(self):
+        key = ('try_finally', 'try_method')
+        assert key in self.test_map
+
+        entry = self.test_map[key]
+        self.assertEqual(entry, [(self.path, 'test_try_finally')])
+
+    def test_ignores_tests_in_except_clauses(self):
+        key = ('try_finally', 'exception_handler')
+        assert key not in self.test_map
+
+    def test_finds_tests_in_finally_clauses(self):
+        key = ('try_finally', 'final_method')
+        assert key in self.test_map
+
+        entry = self.test_map[key]
+        self.assertEqual(entry, [(self.path, 'test_try_finally')])


### PR DESCRIPTION
Had some time in between GCF work. 😃 This should help resolve some of the current test detection failures.

@jmdobry we'll be at ~80% coverage of `python-docs-samples` tests when this is merged.