### PR TITLE
feat(AST parser): include setup methods in test method list

### DIFF
--- a/xunit-autolabeler-v2/ast_parser/core/polyglot_parser.py
+++ b/xunit-autolabeler-v2/ast_parser/core/polyglot_parser.py
@@ -56,7 +56,8 @@ def add_children_drift_data(
         for child in method.children:
             child_methods = [
                 child_method for child_method in source_methods if
-                child == child_method.name
+                child == child_method.name and
+                method.source_path == child_method.source_path
             ]
 
             if child_methods:

--- a/xunit-autolabeler-v2/ast_parser/python/source_parser.py
+++ b/xunit-autolabeler-v2/ast_parser/python/source_parser.py
@@ -46,6 +46,10 @@ def _get_method_children(expr: Any) -> List[Any]:
         for sub_expr in expr.body:
             results += _get_method_children(sub_expr)
 
+    if hasattr(expr, 'orelse') and isinstance(expr.orelse, list):
+        for sub_expr in expr.orelse:
+            results += _get_method_children(sub_expr)
+
     if hasattr(expr, 'value'):
         results += _get_method_children(expr.value)
 
@@ -84,7 +88,11 @@ def _get_ending_line(expr: Any) -> int:
             highest_line_no = final_stmt.lineno
 
         body_is_valid = hasattr(final_stmt, 'body') and final_stmt.body
-        if body_is_valid and isinstance(final_stmt.body, list):
+        if hasattr(final_stmt, 'orelse') and final_stmt.orelse:
+            # 'orelse' should take priority over 'body'
+            # (as it always has a lower ending line)
+            final_stmt = final_stmt.orelse[-1]
+        elif body_is_valid and isinstance(final_stmt.body, list):
             final_stmt = final_stmt.body[-1]
         elif body_is_valid:
             final_stmt = final_stmt.body

--- a/xunit-autolabeler-v2/ast_parser/python/source_parser_ending_line_test.py
+++ b/xunit-autolabeler-v2/ast_parser/python/source_parser_ending_line_test.py
@@ -42,10 +42,12 @@ def _methods():
         (2, 34, 40),
         (3, 43, 49),
         (4, 52, 55),
-        (5, 59, 66),
-        (6, 70, 77),
-        (7, 81, 88),
-        (8, 92, 97)
+        (5, 58, 66),
+        (6, 69, 77),
+        (7, 80, 88),
+        (8, 91, 97),
+        (9, 99, 106),
+        (10, 109, 116)
     ],
     ids=[
         'one_level_function',
@@ -57,6 +59,8 @@ def _methods():
         'returning_multiline_dict',
         'returning_multiline_array',
         'returning_multiline_list_comp',
+        'if_else',
+        'if_elseif'
     ]
 )
 def test_ending_line(method_idx, start, end, _methods):
@@ -66,4 +70,11 @@ def test_ending_line(method_idx, start, end, _methods):
     drift = method.drift
 
     assert drift.start_line == start
-    assert drift.end_line == end
+
+    # This differs between py3.8 and py3.9
+    # The difference doesn't affect parser logic,
+    # so we allow both possible results.
+    #
+    # Likely caused by
+    # https://bugs.python.org/issue34822
+    assert drift.end_line in [end - 1, end]

--- a/xunit-autolabeler-v2/ast_parser/python/source_parser_test.py
+++ b/xunit-autolabeler-v2/ast_parser/python/source_parser_test.py
@@ -144,6 +144,7 @@ class GetEndingLineNumberTest(unittest.TestCase):
         del fake_elem.iter
         del fake_elem.value
         del fake_elem.values
+        del fake_elem.orelse
 
         fake_elem.lineno = lineno
 
@@ -230,6 +231,12 @@ class GetEndingLineNumberTest(unittest.TestCase):
     def test_handles_value(self):
         elem = self._clear_fake_elem(1)
         elem.value = self._clear_fake_elem(2)
+
+        assert source_parser._get_ending_line(elem) == 2
+
+    def test_handles_orelse(self):
+        elem = self._clear_fake_elem(1)
+        elem.orelse = [self._clear_fake_elem(2)]
 
         assert source_parser._get_ending_line(elem) == 2
 

--- a/xunit-autolabeler-v2/ast_parser/python/test_data/new_tests/ending_lines.py
+++ b/xunit-autolabeler-v2/ast_parser/python/test_data/new_tests/ending_lines.py
@@ -55,7 +55,6 @@ def nested_with_statements():
         return 0
 
 
-# TODOs
 def ending_tuple():
     return (
         # dummy comment
@@ -95,3 +94,23 @@ def ending_list_comp():
             # to take up
             # three lines
             in range(2)]
+
+
+def ending_if_else():
+    if 1 == 2:
+        return True
+    else:
+        # dummy comment
+        # to take up
+        # three lines
+        return False
+
+
+def ending_if_elif():
+    if 1 == 2:
+        return True
+    elif True:
+        # dummy comment
+        # to take up
+        # three lines
+        return False

--- a/xunit-autolabeler-v2/ast_parser/python/test_data/new_tests/fixture_detection_test.py
+++ b/xunit-autolabeler-v2/ast_parser/python/test_data/new_tests/fixture_detection_test.py
@@ -1,4 +1,4 @@
-# Copyright 2020 Google LLC. All Rights Reserved.
+# Copyright 2021 Google LLC. All Rights Reserved.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/xunit-autolabeler-v2/ast_parser/python/test_data/new_tests/fixture_detection_test.py
+++ b/xunit-autolabeler-v2/ast_parser/python/test_data/new_tests/fixture_detection_test.py
@@ -1,4 +1,4 @@
-# Copyright 2020 Google LLC.
+# Copyright 2020 Google LLC. All Rights Reserved.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -12,15 +12,20 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+def setup():
+    pass
 
-import re
+def init():
+    pass
 
+def setup_something():
+    pass
 
-TAG_LINE_RANGE = 8
+def init_something():
+    pass
 
-# Per https://flask.palletsprojects.com/en/1.1.x/quickstart/#http-methods
-FLASK_DEFAULT_METHODS = ('get',)
+def another_setup():
+    pass
 
-TEST_FILE_MARKER = 'test.py'
-
-TEST_METHOD_REGEX = re.compile('(^test_|((^|_)(setup|init)))')
+def another_init():
+    pass

--- a/xunit-autolabeler-v2/ast_parser/python/test_parser.py
+++ b/xunit-autolabeler-v2/ast_parser/python/test_parser.py
@@ -18,8 +18,9 @@ import os
 import sys
 from typing import Any, Dict, List, Tuple
 
-from ast_parser.core import constants
+from ast_parser.core import constants as core_constants
 
+from . import constants as python_constants
 from . import drift_test
 
 
@@ -41,8 +42,8 @@ def _get_test_nodes(parsed_nodes: List[Any]) -> List[Any]:
             # Concatenate node.body (which is an array)
             possible_test_nodes += node.body
 
-    return [node for node in possible_test_nodes
-            if hasattr(node, 'name') and node.name.startswith('test_')]
+    return [node for node in possible_test_nodes if hasattr(node, 'name') and
+            python_constants.TEST_METHOD_REGEX.search(node.name)]
 
 
 def get_test_methods(test_path: str) -> List[Any]:
@@ -130,8 +131,8 @@ def get_test_key_to_snippet_map(
             func = expr.func
 
             if hasattr(func.value, 'id') and \
-               func.value.id in constants.HTTP_CLASS_NAMES and \
-               func.attr in constants.HTTP_METHOD_NAMES and \
+               func.value.id in core_constants.HTTP_CLASS_NAMES and \
+               func.attr in core_constants.HTTP_METHOD_NAMES and \
                hasattr(expr.args[0], 's'):
                 return [drift_test.DriftTest(
                     url=expr.args[0].s,
@@ -157,7 +158,7 @@ def get_test_key_to_snippet_map(
                 results += [subexpr for subexpr
                             in __recursor__(subexpr) if subexpr]
 
-        if constants.BODY_IS_ARRAY_REGEX.search(type_str):
+        if core_constants.BODY_IS_ARRAY_REGEX.search(type_str):
             for subexpr in expr.body:
                 results += [subexpr for subexpr
                             in __recursor__(subexpr) if subexpr]

--- a/xunit-autolabeler-v2/ast_parser/python/test_parser_test.py
+++ b/xunit-autolabeler-v2/ast_parser/python/test_parser_test.py
@@ -62,6 +62,16 @@ class GetTestMethodsTests(unittest.TestCase):
         assert test_methods[0].name == 'test_first'
         assert test_methods[1].name == 'test_second'
 
+    def test_detects_fixture_methods(self):
+        path = os.path.join(
+            TEST_DATA_DIR,
+            'new_tests/fixture_detection_test.py'
+        )
+
+        test_methods = test_parser.get_test_methods(path)
+
+        assert len(test_methods) == 6
+
 
 def test_warns_on_invalid_file(capsys):
     # This test cannot be within a class, since it uses the capsys fixture


### PR DESCRIPTION
- [x] Include setup methods (methods with `init` or `setup` in their name) in the test method list.
- [x] Add support for `else` clauses to child method search.

@jmdobry FYI - this gets us (incrementally) closer to our automated test detection goal. I suspect there will be 1 (maybe 2) PRs after this before I hand this off to your team.