### PR TITLE
feat(AST parser): support tests with URL params

### DIFF
--- a/xunit-autolabeler-v2/ast_parser/python/test_data/parser/flask/flask_parameterized_test.py
+++ b/xunit-autolabeler-v2/ast_parser/python/test_data/parser/flask/flask_parameterized_test.py
@@ -1,4 +1,4 @@
-# Copyright 2020 Google LLC. All Rights Reserved.
+# Copyright 2021 Google LLC. All Rights Reserved.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/xunit-autolabeler-v2/ast_parser/python/test_data/parser/flask/flask_parameterized_test.py
+++ b/xunit-autolabeler-v2/ast_parser/python/test_data/parser/flask/flask_parameterized_test.py
@@ -1,0 +1,27 @@
+# Copyright 2020 Google LLC. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import main
+
+import pytest
+
+
+@pytest.fixture
+def app():
+    main.app.testing = True
+    return main.app.test_client()
+
+
+def test_index_param(app):
+    assert app.get('/?foo=bar').status_code == 200

--- a/xunit-autolabeler-v2/ast_parser/python/test_parser.py
+++ b/xunit-autolabeler-v2/ast_parser/python/test_parser.py
@@ -134,7 +134,7 @@ def get_test_key_to_snippet_map(
                func.attr in constants.HTTP_METHOD_NAMES and \
                hasattr(expr.args[0], 's'):
                 return [drift_test.DriftTest(
-                    url=expr.args[0].s,
+                    url=expr.args[0].s.split('?')[0],
                     http_method=func.attr
                 )]
 

--- a/xunit-autolabeler-v2/ast_parser/python/test_parser_test.py
+++ b/xunit-autolabeler-v2/ast_parser/python/test_parser_test.py
@@ -92,6 +92,19 @@ class GetTestToMethodMapSmokeTests(unittest.TestCase):
         assert entry[0] == (path, 'test_print_name')
         assert entry[1] == (path, 'test_print_hello_world')
 
+    def test_handles_http_methods(self):
+        path = os.path.join(
+            TEST_DATA_DIR,
+            'parser/flask/flask_parameterized_test.py'
+        )
+
+        test_methods = test_parser.get_test_methods(path)
+        test_map = test_parser.get_test_key_to_snippet_map(test_methods)
+
+        key = ('get', '/')
+
+        assert key in test_map
+
     def test_handles_class_and_method_names(self):
         path = os.path.join(
             TEST_DATA_DIR,


### PR DESCRIPTION
This is necessary for some Firebase-related samples.